### PR TITLE
fix: Security fix for forgotten credentials

### DIFF
--- a/radar/auth/forgot_password.py
+++ b/radar/auth/forgot_password.py
@@ -31,7 +31,7 @@ def forgot_password(username, email):
 
     # User not found
     if user is None:
-        raise UserNotFound()
+        return user
 
     token, token_hash = generate_reset_password_token()
 

--- a/radar/auth/forgot_username.py
+++ b/radar/auth/forgot_username.py
@@ -8,10 +8,15 @@ def forgot_username(email):
 
     # No users with that email
     if len(users) == 0:
-        raise UserNotFound()
+        return None
 
     # Send username reminder email
-    send_email_from_template(email, 'RaDaR Username Reminder', 'forgot_username', {
-        'email': email,
-        'users': users,
-    })
+    send_email_from_template(
+        email,
+        "RaDaR Username Reminder",
+        "forgot_username",
+        {
+            "email": email,
+            "users": users,
+        },
+    )


### PR DESCRIPTION
Changed the messaging and behavior around resetting passwords. It should no longer be obvious if an attempt was successful or not.