### PR TITLE
Add "units" and "other" options to medication models

### DIFF
--- a/radar/models/medications.py
+++ b/radar/models/medications.py
@@ -49,6 +49,8 @@ MEDICATION_DOSE_UNITS = OrderedDict(
         ("patch", "Patch"),
         ("sachet", "Sachet"),
         ("tbsp", "Table Spoon"),
+        ("units", "Units"),
+        ("other", "Other"),
     ]
 )
 


### PR DESCRIPTION
Extended the MEDICATION_UNITS_CHOICES with two additional options: "units" and "other".