### PR TITLE
feat(RDR-921): Fix data send for no consent

### DIFF
--- a/tests/ukrdc_importer/test_withdrawn_consent.py
+++ b/tests/ukrdc_importer/test_withdrawn_consent.py
@@ -1,66 +1,75 @@
 from unittest.mock import MagicMock
-
 import pytest
 
 from radar.models.groups import Group
 from radar.models.patients import Patient
+from radar.models.groups import GroupPatient
 from radar.ukrdc_importer.tasks import withdrawn_consent_cohorts
+
 
 @pytest.fixture
 def mock_patient():
     """Fixture to create a mock patient."""
     patient = MagicMock(spec=Patient)
-    patient.cohorts = []
+    patient.groups = []  # matches function logic
     return patient
 
 
-def test_no_cohorts(mock_patient):
-    """Test case: Patient has no cohorts."""
-    mock_patient.cohorts = []
+def make_group_patient(group_id, code, to_date=None):
+    """Helper to make a mock GroupPatient with given group and to_date."""
+    gp = MagicMock(spec=GroupPatient)
+    gp.group = Group(id=group_id, code=code)
+    gp.to_date = to_date
+    return gp
+
+
+def test_no_groups(mock_patient):
+    """Test case: Patient has no group associations."""
+    mock_patient.groups = []
     assert not withdrawn_consent_cohorts(mock_patient)
 
 
 def test_not_withdrawn_consent(mock_patient):
-    """Test case: Patient has cohorts but none match withdrawn consent criteria."""
-    mock_patient.cohorts = [
-        Group(id=101, code="OTHER"),
-        Group(id=102, code="DIFFERENT"),
+    """Test case: Patient has groups but none match withdrawn consent criteria."""
+    mock_patient.groups = [
+        make_group_patient(101, "OTHER"),
+        make_group_patient(102, "DIFFERENT"),
     ]
     assert not withdrawn_consent_cohorts(mock_patient)
 
 
 def test_withdrawn_consent_match_code_only(mock_patient):
-    """Test case: Patient has a cohort matching withdrawn consent code but not ID."""
-    mock_patient.cohorts = [Group(id=999, code="CONS_WDTWN")]
-    assert not withdrawn_consent_cohorts(mock_patient)
+    """Test case: Patient has a group matching withdrawn consent code but not ID."""
+    mock_patient.groups = [make_group_patient(999, "CONS_WDTWN")]
+    assert withdrawn_consent_cohorts(mock_patient)  # ✅ should return True
 
 
 def test_withdrawn_consent_match_id_only(mock_patient):
-    """Test case: Patient has a cohort matching withdrawn consent ID but not code."""
-    mock_patient.cohorts = [Group(id=182, code="SOMECODE")]
-    assert not withdrawn_consent_cohorts(mock_patient)
+    """Test case: Patient has a group matching withdrawn consent ID but not code."""
+    mock_patient.groups = [make_group_patient(182, "SOMECODE")]
+    assert withdrawn_consent_cohorts(mock_patient)  # ✅ should return True
 
 
 def test_withdrawn_consent_exact_match(mock_patient):
-    """Test case: Patient has a cohort matching both withdrawn consent code and ID."""
-    mock_patient.cohorts = [Group(id=182, code="CONS_WDTWN")]
+    """Test case: Patient has a group matching both withdrawn consent code and ID."""
+    mock_patient.groups = [make_group_patient(182, "CONS_WDTWN")]
     assert withdrawn_consent_cohorts(mock_patient)
 
 
-def test_multiple_cohorts_no_match(mock_patient):
-    """Test case: Patient has multiple cohorts, none of which match withdrawn consent."""
-    mock_patient.cohorts = [
-        Group(id=101, code="OTHER"),
-        Group(id=200, code="ANOTHER"),
+def test_multiple_groups_no_match(mock_patient):
+    """Test case: Patient has multiple groups, none of which match withdrawn consent."""
+    mock_patient.groups = [
+        make_group_patient(101, "OTHER"),
+        make_group_patient(200, "ANOTHER"),
     ]
     assert not withdrawn_consent_cohorts(mock_patient)
 
 
-def test_multiple_cohorts_with_match(mock_patient):
-    """Test case: Patient has multiple cohorts, one of which matches withdrawn consent."""
-    mock_patient.cohorts = [
-        Group(id=101, code="OTHER"),
-        Group(id=152, code="NOCON"),  # Matches both code and ID
-        Group(id=200, code="ANOTHER"),
+def test_multiple_groups_with_match(mock_patient):
+    """Test case: Patient has multiple groups, one of which matches withdrawn consent."""
+    mock_patient.groups = [
+        make_group_patient(101, "OTHER"),
+        make_group_patient(152, "NOCON"),  # Matches both code and ID
+        make_group_patient(200, "ANOTHER"),
     ]
     assert withdrawn_consent_cohorts(mock_patient)


### PR DESCRIPTION
@andyatterton swapped condition to include the to_date, hope this works, I have been trying for an hour or so to fix my local radar stack but everything is broken I think a lot of this stems from the code being on python 3.6 etc, I wonder if this repo should be updated to use poetry and a newer version of python 