### PR TITLE
RDR-911

### DIFF
--- a/radar/ukrdc_importer/serializers.py
+++ b/radar/ukrdc_importer/serializers.py
@@ -48,7 +48,7 @@ class EthnicGroupSerializer(serializers.Serializer):
         # Check if both are empty / missing / whitespace-only
         if not (code and str(code).strip()) and not (description and str(description).strip()):
             # Skip this field entirely in parent serializer
-            raise serializers.SkipField()
+            raise None
 
         # Otherwise, return the valid data
         return data

--- a/radar/ukrdc_importer/serializers.py
+++ b/radar/ukrdc_importer/serializers.py
@@ -37,6 +37,21 @@ class CodeOrDescriptionSerializer(serializers.Serializer):
 
         raise ValidationError({"code or description": "At least one is required"})
 
+class EthnicGroupSerializer(serializers.Serializer):
+    code = fields.StringField(required=False)
+    description = fields.StringField(required=False)
+
+    def validate(self, data):
+        # Get values
+        code = data.get("code")
+        description = data.get("description")
+        # Check if both are empty / missing / whitespace-only
+        if not (code and str(code).strip()) and not (description and str(description).strip()):
+            # Skip this field entirely in parent serializer
+            raise serializers.SkipField()
+
+        # Otherwise, return the valid data
+        return data
 
 class EnteringOrganizationSerializer(serializers.Serializer):
     code = fields.StringField()
@@ -70,7 +85,7 @@ class PatientSerializer(serializers.Serializer):
     birth_time = SDADateTimeField(required=False)
     death_time = SDADateTimeField(required=False)
     gender = CodeDescriptionSerializer(required=False)
-    ethnic_group = CodeOrDescriptionSerializer(required=False)
+    ethnic_group = EthnicGroupSerializer(required=False)
     contact_info = ContactInfoSerializer(required=False)
 
 


### PR DESCRIPTION
Some patients on radar sync do not have a ethnic code, the serializer states that this is not required but has a validation step that requires either code or desc, I have therefore made a new serializer that in the case of neither it returns none and should skip/not throw this error.